### PR TITLE
fix: swap condition and function in joins

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -21,8 +21,8 @@ mappings:
       - p: predicate
         o:
           - mapping: triplesmap2
-            function:
-              condition: equal
+            condition:
+              function: equal
               parameters:
                 - [str1, $()]
                 - [str2, $()]


### PR DESCRIPTION
According to the current [YARRRML draft ](https://rml.io/yarrrml/spec/#referring-to-other-mappings) the keywords **function** and **condition**, which are used for joins, should be swapped.